### PR TITLE
Upgrade to channels_redis v4.0b1

### DIFF
--- a/metadeploy/consumer_utils.py
+++ b/metadeploy/consumer_utils.py
@@ -18,7 +18,7 @@ async def get_set_message_semaphore(channel_layer, message):
     Used to prevent sending the same message twice within 5 seconds."""
     msg_hash = message_to_hash(message)
     async with channel_layer.connection(0) as connection:
-        return await connection.set(msg_hash, 1, expire=5, exist="SET_IF_NOT_EXIST")
+        return await connection.set(msg_hash, 1, ex=5, nx=True)
 
 
 async def clear_message_semaphore(channel_layer, message):

--- a/requirements/prod.in
+++ b/requirements/prod.in
@@ -11,7 +11,7 @@ ansi2html
 bleach
 boto3
 channels
-channels-redis
+channels-redis==4.0.0b1
 django-allauth
 django-colorfield
 django-binary-database-files

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -4,8 +4,6 @@
 #
 #    pip-compile --output-file=requirements/prod.txt requirements/prod.in
 #
-aioredis==1.3.1
-    # via channels-redis
 ansi2html==1.8.0
     # via -r requirements/prod.in
 appdirs==1.4.4
@@ -19,9 +17,7 @@ asgiref==3.5.2
     #   daphne
     #   django
 async-timeout==4.0.2
-    # via
-    #   aioredis
-    #   redis
+    # via redis
 attrs==21.4.0
     # via
     #   automat
@@ -60,7 +56,7 @@ channels==3.0.5
     # via
     #   -r requirements/prod.in
     #   channels-redis
-channels-redis==3.4.1
+channels-redis==4.0.0b1
     # via -r requirements/prod.in
 charset-normalizer==2.0.12
     # via
@@ -185,8 +181,6 @@ gvgen==1.0
     #   snowfakery
 hashids==1.3.1
     # via django-hashid-field
-hiredis==2.0.0
-    # via aioredis
 honcho==1.1.0
     # via -r requirements/prod.in
 humanfriendly==10.0
@@ -314,6 +308,7 @@ pyyaml==6.0
     #   snowfakery
 redis==4.3.4
     # via
+    #   channels-redis
     #   django-redis
     #   django-rq
     #   rq


### PR DESCRIPTION
`channels_redis` < 4 uses `aioredis` to connect with Redis. For some reason `aioredis` was hanging when send WS notifications to the frontend, which locked the application at different places (most importantly it prevented job scheduling or completion). `channels_redis` v4 no longer depends on `aioredis`, which at least in local development seems to resolve the issue.