### PR TITLE
Pin back NewRelic dependency.

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -2,11 +2,10 @@
 import os
 import sys
 
-from newrelic import agent
 
 if __name__ == "__main__":
-    agent.initialize()
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
+    # TODO: Remove this entire block? Seems likely to be cruft
     try:
         from django.core.management import execute_from_command_line
     except ImportError:
@@ -15,11 +14,11 @@ if __name__ == "__main__":
         # exceptions on Python 2.
         try:
             import django  # noqa: F401
-        except ImportError:
+        except ImportError as exc:
             raise ImportError(
                 "Couldn't import Django. Are you sure it's installed and "
                 "available on your PYTHONPATH environment variable? Did you "
                 "forget to activate a virtual environment?"
-            )
+            ) from exc
         raise
     execute_from_command_line(sys.argv)

--- a/metadeploy/api/serializers.py
+++ b/metadeploy/api/serializers.py
@@ -422,11 +422,16 @@ class JobSerializer(ErrorWarningCountMixin, HashIdModelSerializer):
     plan_slug = serializers.CharField(source="plan.slug", read_only=True)
     results = StepResultsField(required=False)
 
+    # Why `objects` instead of `objects.all()`? The call to `.all()` seems to "freeze"
+    # the resulting queryset when this file is imported. At that point it returns the
+    # objects from the default Site, which means validation fails later when the
+    # serializer is executed on other Site instances. Leaving out `.all()` makes DRF
+    # always re-run the queryset to get fresh objects for each Site.
     plan = serializers.PrimaryKeyRelatedField(
-        queryset=Plan.objects.all(), pk_field=serializers.CharField()
+        queryset=Plan.objects, pk_field=serializers.CharField()
     )
     steps = serializers.PrimaryKeyRelatedField(
-        queryset=Step.objects.all(), many=True, pk_field=serializers.CharField()
+        queryset=Step.objects, many=True, pk_field=serializers.CharField()
     )
     error_count = serializers.SerializerMethodField()
     warning_count = serializers.SerializerMethodField()

--- a/metadeploy/asgi.py
+++ b/metadeploy/asgi.py
@@ -4,16 +4,9 @@ defined in the ASGI_APPLICATION setting.
 """
 
 import os
-import sys
 
 import django
 from channels.routing import get_default_application
-from newrelic import agent
-
-# newrelic patches sqlite in a way that interferes with coverage reporting
-if "pytest_cov" not in sys.modules:  # pragma: no cover
-    agent.initialize()
-    agent.wrap_web_transaction("django.core.handlers.base", "BaseHandler.get_response")
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
 

--- a/metadeploy/consumer_utils.py
+++ b/metadeploy/consumer_utils.py
@@ -18,7 +18,7 @@ async def get_set_message_semaphore(channel_layer, message):
     Used to prevent sending the same message twice within 5 seconds."""
     msg_hash = message_to_hash(message)
     async with channel_layer.connection(0) as connection:
-        return await connection.set(msg_hash, 1, ex=5, nx=True)
+        return await connection.set(msg_hash, 1, expire=5, exist="SET_IF_NOT_EXIST")
 
 
 async def clear_message_semaphore(channel_layer, message):

--- a/metadeploy/rq_worker.py
+++ b/metadeploy/rq_worker.py
@@ -1,20 +1,5 @@
 from django.db import DatabaseError, InterfaceError, connections
-from newrelic import agent
-from rq.job import Job
 from rq.worker import HerokuWorker, Worker
-
-
-def wrap_job_as_background_task(Job):
-    orig = Job.perform
-
-    def wrapper(self):
-        with agent.BackgroundTask(agent.application(), self.func_name):
-            return orig(self)
-
-    Job.perform = wrapper
-
-
-wrap_job_as_background_task(Job)
 
 
 class ConnectionClosingWorkerMixin:
@@ -33,11 +18,9 @@ class ConnectionClosingWorkerMixin:
 
     def perform_job(self, *args, **kwargs):
         self.close_database()
-        agent.register_application(timeout=10.0)
         try:
             return super().perform_job(*args, **kwargs)
         finally:
-            agent.shutdown_agent(timeout=10.0)
             self.close_database()
 
     def work(self, *args, **kwargs):

--- a/metadeploy/tests/rq_worker.py
+++ b/metadeploy/tests/rq_worker.py
@@ -4,22 +4,6 @@ import pytest
 from django.db import DatabaseError, InterfaceError
 from django_rq import get_worker
 
-from metadeploy.rq_worker import wrap_job_as_background_task
-
-
-def test_wrap_job_as_background_task(mocker):
-    mocker.patch("newrelic.agent.BackgroundTask")
-    mocker.patch("newrelic.agent.application")
-    mock_perform = MagicMock()
-
-    class Job:
-        func_name = "func"
-        perform = mock_perform
-
-    wrap_job_as_background_task(Job)
-    Job().perform()
-    mock_perform.assert_called_once()
-
 
 class TestConnectionClosingWorker:
     def test_close_database__good(self, mocker):

--- a/requirements/prod.in
+++ b/requirements/prod.in
@@ -11,7 +11,7 @@ ansi2html
 bleach
 boto3
 channels
-channels-redis==4.0.0b1
+channels-redis
 django-allauth
 django-colorfield
 django-binary-database-files

--- a/requirements/prod.in
+++ b/requirements/prod.in
@@ -31,7 +31,6 @@ drf-spectacular
 github3.py
 honcho
 logfmt
-newrelic==7.12.0.176
 psycopg2-binary
 rq
 sentry-sdk

--- a/requirements/prod.in
+++ b/requirements/prod.in
@@ -31,7 +31,7 @@ drf-spectacular
 github3.py
 honcho
 logfmt
-newrelic
+newrelic==7.12.0.176
 psycopg2-binary
 rq
 sentry-sdk

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -243,8 +243,6 @@ markupsafe==2.0.1
     #   snowfakery
 msgpack==1.0.4
     # via channels-redis
-newrelic==7.12.0.176
-    # via -r requirements/prod.in
 oauthlib==3.2.0
     # via requests-oauthlib
 packaging==21.3

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -4,6 +4,8 @@
 #
 #    pip-compile --output-file=requirements/prod.txt requirements/prod.in
 #
+aioredis==1.3.1
+    # via channels-redis
 ansi2html==1.8.0
     # via -r requirements/prod.in
 appdirs==1.4.4
@@ -17,7 +19,9 @@ asgiref==3.5.2
     #   daphne
     #   django
 async-timeout==4.0.2
-    # via redis
+    # via
+    #   aioredis
+    #   redis
 attrs==21.4.0
     # via
     #   automat
@@ -56,7 +60,7 @@ channels==3.0.5
     # via
     #   -r requirements/prod.in
     #   channels-redis
-channels-redis==4.0.0b1
+channels-redis==3.4.1
     # via -r requirements/prod.in
 charset-normalizer==2.0.12
     # via
@@ -181,6 +185,8 @@ gvgen==1.0
     #   snowfakery
 hashids==1.3.1
     # via django-hashid-field
+hiredis==2.0.0
+    # via aioredis
 honcho==1.1.0
     # via -r requirements/prod.in
 humanfriendly==10.0
@@ -308,7 +314,6 @@ pyyaml==6.0
     #   snowfakery
 redis==4.3.4
     # via
-    #   channels-redis
     #   django-redis
     #   django-rq
     #   rq

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -243,7 +243,7 @@ markupsafe==2.0.1
     #   snowfakery
 msgpack==1.0.4
     # via channels-redis
-newrelic==7.14.0.177
+newrelic==7.12.0.176
     # via -r requirements/prod.in
 oauthlib==3.2.0
     # via requests-oauthlib


### PR DESCRIPTION
![](https://source.unsplash.com/featured/?cute,animal&220825)

In testing locally, it seems like this newrelic version upgrade was the culprit of the hanging WS events. I think we could potentially remove newrelic entirely? I don't love how their agent has to be so embedded into the processes.

I also don't think this necessarily needs to replace #1 and #2 -- though personally I might recommend we wait to upgrade channels-redis until a full version is released.