### PR TITLE
Update GitHub Actions output syntax

### DIFF
--- a/.github/setup-docker-compose/action.yml
+++ b/.github/setup-docker-compose/action.yml
@@ -12,7 +12,7 @@ inputs:
     description: Refer to build-push-action for usage
   cache-to:
     required: false
-    default: ''
+    default: ""
     description: Refer to build-push-action for usage
 
 outputs:
@@ -45,4 +45,4 @@ runs:
       run: |
         # The weird ",," syntax forces lowercase
         docker tag $TAG ${REPO,,}_${{ inputs.service }}:latest
-        echo "::set-output name=tag::$TAG"
+        echo "tag=$TAG" >> $GITHUB_OUTPUT

--- a/.github/workflows/upgrade-deps.yml
+++ b/.github/workflows/upgrade-deps.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch: # Allow running on-demand
   schedule:
     # Every Monday at 8:00 UTC (4:00 Eastern)
-    - cron: '0 8 * * 1'
+    - cron: "0 8 * * 1"
 
 jobs:
   upgrade:
@@ -39,7 +39,7 @@ jobs:
         id: changes
         # prettier-ignore
         run:
-          echo "::set-output name=count::$(git status --porcelain=v1 2>/dev/null | wc -l)"
+          echo "count=$(git status --porcelain=v1 2>/dev/null | wc -l)" >> $GITHUB_OUTPUT
       - name: Commit & push changes
         if: steps.changes.outputs.count > 0
         run: |


### PR DESCRIPTION
![](https://source.unsplash.com/featured/?cute,animal&221028)
<!-- Swap `CHANGE_ME` for a random string to get a different image -->

https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/